### PR TITLE
dln: Fix bad environment assumptions

### DIFF
--- a/src/dln.c
+++ b/src/dln.c
@@ -26,11 +26,20 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#ifdef _WIN32
 #ifndef PATH_ENV
 # define PATH_ENV "Path"
 #endif
 #ifndef PATH_SEP
 # define PATH_SEP ";"
+#endif
+#else
+#ifndef PATH_ENV
+# define PATH_ENV "PATH"
+#endif
+#ifndef PATH_SEP
+# define PATH_SEP ":"
+#endif
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
This fixes an issue where environment lookups didn't work as expected.

That is, the environment lookup was only (seemingly) right for Windows
environments. It was defaulting to the "Path" environment variable.

This does not fail in conventional POSIX-ish setups, since the fallback
is to look in a bunch of default paths when PATH_ENV is null.

This, however, fails in sandboxed and isolated situations where
dependencies are injected through PATH. This is why it fails on NixOS.

Furthermore, the path separator also defaulted to a non-POSIXly correct
one.

These changes hinge on the Windows conditional, and makes environment
lookups work correctly on non-windows platforms.