### PR TITLE
Fix wrong usage of `mrb_get_args()`.

### DIFF
--- a/src/signal.c
+++ b/src/signal.c
@@ -221,14 +221,12 @@ signo2signm(int no)
 static mrb_value
 mrb_sig_signame(mrb_state *mrb, mrb_value klass)
 {
-    mrb_value sigo;
     int signo;
     const char *signame;
 
-    mrb_get_args(mrb, "i", &sigo);
+    mrb_get_args(mrb, "i", &signo);
 
-    signo   = mrb_fixnum(sigo);
-    signame = signo2signm(signo);
+    signame = signo2signm((int)signo);
 
     if (!signame)
         return mrb_nil_value();


### PR DESCRIPTION
Specifier `i` takes `mrb_int`, not `mrb_value`.